### PR TITLE
Adding task role policy to module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ module "service" {
 }
 
 module "taskdef" {
-  source = "github.com/mergermarket/tf_ecs_task_definition"
+  source = "github.com/mergermarket/tf_ecs_task_definition_with_task_role"
 
   family                = "${var.env}-${lookup(var.release, "component")}${var.name_suffix}"
   container_definitions = ["${module.service_container_definition.rendered}"]

--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,7 @@ module "taskdef" {
 
   family                = "${var.env}-${lookup(var.release, "component")}${var.name_suffix}"
   container_definitions = ["${module.service_container_definition.rendered}"]
+  policy                = "${var.task_role_policy}"
 }
 
 module "service_container_definition" {

--- a/variables.tf
+++ b/variables.tf
@@ -74,3 +74,14 @@ variable "logentries_token" {
   type        = "string"
   default     = ""
 }
+
+variable "task_role_policy" {
+  description = "IAM policy document to apply to the tasks via a task role"
+  type        = "string"
+  default     = <<END
+{
+  "Version": "2012-10-17",
+  "Statement": []
+}
+END
+}


### PR DESCRIPTION
We want to be able to give the service a task role policy so that it can
use other AWS services.

At best guess, I _think_ we can merge this. 🤷‍♂️ 

If we're setting a default it shouldn't affect any services already using this module.