### PR TITLE
Expose volume and mountpoint parameters

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,7 @@ module "taskdef" {
   family                = "${var.env}-${lookup(var.release, "component")}${var.name_suffix}"
   container_definitions = ["${module.service_container_definition.rendered}"]
   policy                = "${var.task_role_policy}"
+  volume                = "${var.taskdef_volume}"
 }
 
 module "service_container_definition" {
@@ -35,6 +36,7 @@ module "service_container_definition" {
   memory             = "${var.memory}"
   container_port     = "${var.port}"
   nofile_soft_ulimit = "${var.nofile_soft_ulimit}"
+  mountpoint     = "${var.container_mountpoint}"
 
   container_env = "${merge(
     map(

--- a/variables.tf
+++ b/variables.tf
@@ -97,3 +97,15 @@ variable "task_role_policy" {
 }
 END
 }
+
+variable "taskdef_volume" {
+  description = "Map containing 'name' and 'host_path' used to add a volume mapping to the taskdef."
+  type        = "map"
+  default     = {}
+}
+
+variable "container_mountpoint" {
+  description = "Map containing 'sourceVolume', 'containerPath' and 'readOnly' (optional) to map a volume into a container."
+  type        = "map"
+  default     = {}
+}


### PR DESCRIPTION
To allow volumes to be mapped to containers (e.g. for confluence)