### PR TITLE
Perameterise min and max healthy percentage

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,13 +9,15 @@ module "ecs_update_monitor" {
 module "service" {
   source = "github.com/mergermarket/tf_load_balanced_ecs_service?ref=no-target-group"
 
-  name             = "${var.env}-${lookup(var.release, "component")}${var.name_suffix}"
-  cluster          = "${var.ecs_cluster}"
-  task_definition  = "${module.taskdef.arn}"
-  container_name   = "${lookup(var.release, "component")}${var.name_suffix}"
-  container_port   = "${var.port}"
-  desired_count    = "${var.desired_count}"
-  target_group_arn = "${var.target_group_arn}"
+  name                               = "${var.env}-${lookup(var.release, "component")}${var.name_suffix}"
+  cluster                            = "${var.ecs_cluster}"
+  task_definition                    = "${module.taskdef.arn}"
+  container_name                     = "${lookup(var.release, "component")}${var.name_suffix}"
+  container_port                     = "${var.port}"
+  desired_count                      = "${var.desired_count}"
+  target_group_arn                   = "${var.target_group_arn}"
+  deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
+  deployment_maximum_percent         = "${var.deployment_maximum_percent}"
 }
 
 module "taskdef" {

--- a/variables.tf
+++ b/variables.tf
@@ -121,3 +121,13 @@ variable "container_labels" {
   type        = "map"
   default     = {}
 }
+
+variable "deployment_minimum_healthy_percent" {
+  description = "The minimumHealthyPercent represents a lower limit on the number of your service's tasks that must remain in the RUNNING state during a deployment, as a percentage of the desiredCount (rounded up to the nearest integer)."
+  default     = "100"
+}
+
+variable "deployment_maximum_percent" {
+  description = "The maximumPercent parameter represents an upper limit on the number of your service's tasks that are allowed in the RUNNING or PENDING state during a deployment, as a percentage of the desiredCount (rounded down to the nearest integer)."
+  default     = "200"
+}


### PR DESCRIPTION
So that we can deploy singleton services like confluence.