### PR TITLE
Logging to stream

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -81,9 +81,9 @@ resource "aws_cloudwatch_log_group" "stderr" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "kinesis_log_stdout_stream" {
-  count           = "${var.subscription_arn != "" ? 1 : 0}"
+  count           = "${var.log_subscription_arn != "" ? 1 : 0}"
   name            = "kinesis-log-stdout-stream-${local.service_name}"
-  destination_arn = "${var.subscription_arn}"
+  destination_arn = "${var.log_subscription_arn}"
   log_group_name  = "${local.service_name}${var.name_suffix}-stdout"
   filter_pattern  = ""
 }

--- a/main.tf
+++ b/main.tf
@@ -80,14 +80,10 @@ resource "aws_cloudwatch_log_group" "stderr" {
   retention_in_days = "7"
 }
 
-resource "aws_cloudwatch_log_subscription_filter" "datadog_log_stdout_stream" {
-  count           = "${var.datadog_logging ? 1 : 0}"
-  name            = "datadog-log-stdout-stream-${local.service_name}"
-  destination_arn = "${data.aws_kinesis_stream.datadog_log_stream.arn}"
+resource "aws_cloudwatch_log_subscription_filter" "kinesis_log_stdout_stream" {
+  count           = "${var.subscription_arn != "" ? 1 : 0}"
+  name            = "kinesis-log-stdout-stream-${local.service_name}"
+  destination_arn = "${var.subscription_arn}"
   log_group_name  = "${local.service_name}${var.name_suffix}-stdout"
   filter_pattern  = ""
-}
-
-data "aws_kinesis_stream" "datadog_log_stream" {
-  name = "${var.env}-datadog-log-stream"
 }

--- a/main.tf
+++ b/main.tf
@@ -87,3 +87,11 @@ resource "aws_cloudwatch_log_subscription_filter" "kinesis_log_stdout_stream" {
   log_group_name  = "${local.service_name}${var.name_suffix}-stdout"
   filter_pattern  = ""
 }
+
+resource "aws_cloudwatch_log_subscription_filter" "kinesis_log_stderr_stream" {
+  count           = "${var.log_subscription_arn != "" ? 1 : 0}"
+  name            = "kinesis-log-stdout-stream-${local.service_name}"
+  destination_arn = "${var.log_subscription_arn}"
+  log_group_name  = "${local.service_name}${var.name_suffix}-stderr"
+  filter_pattern  = ""
+}

--- a/main.tf
+++ b/main.tf
@@ -81,7 +81,7 @@ resource "aws_cloudwatch_log_group" "stderr" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "datadog_log_stdout_stream" {
-  count           = "${var.datadog_logs ? 1 : 0}"
+  count           = "${var.datadog_logging ? 1 : 0}"
   name            = "datadog-log-stdout-stream-${local.service_name}"
   destination_arn = "${data.aws_kinesis_stream.datadog_log_stream.arn}"
   log_group_name  = "${local.service_name}${var.name_suffix}-stdout"

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+locals {
+  service_name = "${var.env}-${lookup(var.release, "component")}"
+}
+
 module "ecs_update_monitor" {
   source = "github.com/mergermarket/tf_ecs_update_monitor"
 
@@ -9,7 +13,7 @@ module "ecs_update_monitor" {
 module "service" {
   source = "github.com/mergermarket/tf_load_balanced_ecs_service?ref=no-target-group"
 
-  name                               = "${var.env}-${lookup(var.release, "component")}${var.name_suffix}"
+  name                               = "${local.service_name}${var.name_suffix}"
   cluster                            = "${var.ecs_cluster}"
   task_definition                    = "${module.taskdef.arn}"
   container_name                     = "${lookup(var.release, "component")}${var.name_suffix}"
@@ -23,7 +27,7 @@ module "service" {
 module "taskdef" {
   source = "github.com/mergermarket/tf_ecs_task_definition_with_task_role"
 
-  family                = "${var.env}-${lookup(var.release, "component")}${var.name_suffix}"
+  family                = "${local.service_name}${var.name_suffix}"
   container_definitions = ["${module.service_container_definition.rendered}"]
   policy                = "${var.task_role_policy}"
   volume                = "${var.taskdef_volume}"
@@ -43,8 +47,8 @@ module "service_container_definition" {
 
   container_env = "${merge(
     map(
-      "LOGSPOUT_CLOUDWATCHLOGS_LOG_GROUP_STDOUT", "${var.env}-${lookup(var.release, "component")}${var.name_suffix}-stdout",
-      "LOGSPOUT_CLOUDWATCHLOGS_LOG_GROUP_STDERR", "${var.env}-${lookup(var.release, "component")}${var.name_suffix}-stderr",
+      "LOGSPOUT_CLOUDWATCHLOGS_LOG_GROUP_STDOUT", "${local.service_name}${var.name_suffix}-stdout",
+      "LOGSPOUT_CLOUDWATCHLOGS_LOG_GROUP_STDERR", "${local.service_name}${var.name_suffix}-stderr",
       "STATSD_HOST", "172.17.42.1",
       "STATSD_PORT", "8125",
       "STATSD_ENABLED", "true",
@@ -67,11 +71,23 @@ module "service_container_definition" {
 }
 
 resource "aws_cloudwatch_log_group" "stdout" {
-  name              = "${var.env}-${lookup(var.release, "component")}${var.name_suffix}-stdout"
+  name              = "${local.service_name}${var.name_suffix}-stdout"
   retention_in_days = "7"
 }
 
 resource "aws_cloudwatch_log_group" "stderr" {
-  name              = "${var.env}-${lookup(var.release, "component")}${var.name_suffix}-stderr"
+  name              = "${local.service_name}${var.name_suffix}-stderr"
   retention_in_days = "7"
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "datadog_log_stdout_stream" {
+  count           = "${var.datadog_logs ? 1 : 0}"
+  name            = "datadog-log-stdout-stream-${local.service_name}"
+  destination_arn = "${data.aws_kinesis_stream.datadog_log_stream.arn}"
+  log_group_name  = "${local.service_name}${var.name_suffix}-stdout"
+  filter_pattern  = ""
+}
+
+data "aws_kinesis_stream" "datadog_log_stream" {
+  name = "${var.env}-datadog-log-stream"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -133,7 +133,7 @@ variable "deployment_maximum_percent" {
   default     = "200"
 }
 
-variable "subscription_arn" {
+variable "log_subscription_arn" {
   description = "To enable logging to a kinesis stream"
   default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -133,7 +133,7 @@ variable "deployment_maximum_percent" {
   default     = "200"
 }
 
-variable "datadog" {
+variable "datadog_logging" {
   description = "To enable datadog logging set this variable to 'true'"
   default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -133,7 +133,7 @@ variable "deployment_maximum_percent" {
   default     = "200"
 }
 
-variable "datadog_logging" {
-  description = "To enable datadog logging set this variable to 'true'"
-  default     = false
+variable "subscription_arn" {
+  description = "To enable logging to a kinesis stream"
+  default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -54,7 +54,7 @@ variable "memory" {
 
 variable "nofile_soft_ulimit" {
   type        = "string"
-  description = "The soft ulimit for the number of files in container",
+  description = "The soft ulimit for the number of files in container"
   default     = "4096"
 }
 
@@ -84,7 +84,8 @@ variable "logentries_token" {
 variable "task_role_policy" {
   description = "IAM policy document to apply to the tasks via a task role"
   type        = "string"
-  default     = <<END
+
+  default = <<END
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -130,4 +131,9 @@ variable "deployment_minimum_healthy_percent" {
 variable "deployment_maximum_percent" {
   description = "The maximumPercent parameter represents an upper limit on the number of your service's tasks that are allowed in the RUNNING or PENDING state during a deployment, as a percentage of the desiredCount (rounded down to the nearest integer)."
   default     = "200"
+}
+
+variable "datadog" {
+  description = "To enable datadog logging set this variable to 'true'"
+  default     = false
 }


### PR DESCRIPTION
Enable a kinesis stream to pick up logs on your service by providing a destination to send log groups to with the `${var.subscription_arn}` via a "Cloudwatch Destination Policy ARN"