### PR TITLE
Adding datadog logging in by default

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -84,7 +84,7 @@ resource "aws_cloudwatch_log_group" "stderr" {
 resource "aws_cloudwatch_log_subscription_filter" "kinesis_log_stdout_stream" {
   count           = "${var.log_subscription_arn != "" ? 1 : 0}"
   name            = "kinesis-log-stdout-stream-${local.service_name}"
-  destination_arn = "${var.log_subscription_arn}"
+  destination_arn = "${var.platform_config["datadog_log_subscription_arn"]}"
   log_group_name  = "${local.service_name}${var.name_suffix}-stdout"
   filter_pattern  = ""
 }
@@ -92,7 +92,7 @@ resource "aws_cloudwatch_log_subscription_filter" "kinesis_log_stdout_stream" {
 resource "aws_cloudwatch_log_subscription_filter" "kinesis_log_stderr_stream" {
   count           = "${var.log_subscription_arn != "" ? 1 : 0}"
   name            = "kinesis-log-stdout-stream-${local.service_name}"
-  destination_arn = "${var.log_subscription_arn}"
+  destination_arn = "${var.platform_config["datadog_log_subscription_arn"]}"
   log_group_name  = "${local.service_name}${var.name_suffix}-stderr"
   filter_pattern  = ""
 }


### PR DESCRIPTION
So I realised that if we do this, we don't have to open a whole bunch of PRs and wait for them to get merged.

Just need to check all the config repos for the subscription, and open up account access to svcs accounts in datadog-log-stream repo.

Anyone that has access from platform config should now be sending logs
to datadog.

JIRA: PLAT-1507