### PR TITLE
Output task role name

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,7 @@
 output "task_role_arn" {
   value = "${module.taskdef.task_role_arn}"
 }
+
+output "task_role_name" {
+  value = "${module.taskdef.task_role_name}"
+}


### PR DESCRIPTION
Since this is used by a policy attachement, rather than the arn.