### PR TITLE
Revert "Test pack and distinct instance"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,6 @@ module "service" {
   deployment_maximum_percent         = "${var.deployment_maximum_percent}"
   tags                               = "${var.tags}"
   health_check_grace_period_seconds  = "${var.health_check_grace_period_seconds}"
-  pack_and_distinct                  = "${var.pack_and_distinct}"
 }
 
 module "taskdef" {

--- a/variables.tf
+++ b/variables.tf
@@ -194,9 +194,3 @@ variable "health_check_grace_period_seconds" {
   type = "string"
   default = "0"
 }
-
-variable "pack_and_distinct" {
-  description = "Enable distinct instance and task binpacking for better cluster utilisation. Enter 'true' for clusters with auto scaling groups. Enter 'false' for clusters with no ASG and instant counts less than or equal to desired tasks"
-  type = "string"
-  default = "false"
-}


### PR DESCRIPTION
Reverts mergermarket/tf_ecs_service#25

Causing an error:
aws_ecs_service.service: InvalidParameterException: Creation of service was not idempotent.

Which appears to be due to the use of create before destroy and the resultant service
having the same name as the original, meaning it can't create a new one before
destroying the old